### PR TITLE
Resolved the Azure Web App Deployment Failure

### DIFF
--- a/armtemplates/v1.1.14/RS-UMS-AppServiceTemplate.json
+++ b/armtemplates/v1.1.14/RS-UMS-AppServiceTemplate.json
@@ -90,7 +90,6 @@
       "alwaysOn": true,
       "netFrameworkVersion": "v4.6",
       "remoteDebuggingEnabled": false,
-      "remoteDebuggingVersion": "VS2015",
       "use32BitWorkerProcess": true,
       "virtualApplications": [
         {

--- a/armtemplates/v1.1.14/RS-UMS-AppServiceTemplate.json
+++ b/armtemplates/v1.1.14/RS-UMS-AppServiceTemplate.json
@@ -69,7 +69,6 @@
       "alwaysOn": true,
       "netFrameworkVersion": "v4.6",
       "remoteDebuggingEnabled": false,
-      "remoteDebuggingVersion": "VS2015",
       "use32BitWorkerProcess": true,
       "virtualApplications": [
               {

--- a/armtemplates/v1.2.7/RS-UMS-AppServiceTemplate.json
+++ b/armtemplates/v1.2.7/RS-UMS-AppServiceTemplate.json
@@ -90,7 +90,6 @@
       "alwaysOn": true,
       "netFrameworkVersion": "v4.6",
       "remoteDebuggingEnabled": false,
-      "remoteDebuggingVersion": "VS2015",
       "use32BitWorkerProcess": true,
       "virtualApplications": [
         {

--- a/armtemplates/v1.2.7/RS-UMS-AppServiceTemplate.json
+++ b/armtemplates/v1.2.7/RS-UMS-AppServiceTemplate.json
@@ -69,7 +69,6 @@
       "alwaysOn": true,
       "netFrameworkVersion": "v4.6",
       "remoteDebuggingEnabled": false,
-      "remoteDebuggingVersion": "VS2015",
       "use32BitWorkerProcess": true,
       "virtualApplications": [
               {


### PR DESCRIPTION
The Remote debugging 2015 is removed by the azure from the template deployment. So it failed often.
Hence we removed the parameter.